### PR TITLE
Update to version 0.23!

### DIFF
--- a/Nuget.CredentialProvider.VSS/nuget.credentialprovider.vss.nuspec
+++ b/Nuget.CredentialProvider.VSS/nuget.credentialprovider.vss.nuspec
@@ -3,13 +3,13 @@
   <metadata>
     <id>nuget-credentialprovider-vss</id>
     <title>Nuget CredentialProvider for Microsoft Visual Studio Team Services</title>
-    <version>0.14.0</version>
+    <version>0.23.0</version>
     <authors>Microsoft</authors>
     <owners>Donovan Lange</owners>
     <summary>Enables Nuget to connect to Visual Studio Team Services Package Management NuGet Feeds.</summary>
     <description>The NuGet Credential Provider enables NuGet.exe 3.3+ to connect to Visual Studio Team Services Package Management NuGet feeds. See the NuGet docs for more info: http://docs.nuget.org/Consume/Credential-Providers</description>
     <projectUrl>https://www.visualstudio.com/docs/package/overview</projectUrl>
-    <packageSourceUrl>https://www.nuget.org/packages/Microsoft.VisualStudio.Services.NuGet.CredentialProvider/0.14.0</packageSourceUrl>
+    <packageSourceUrl>https://www.nuget.org/packages/Microsoft.VisualStudio.Services.NuGet.CredentialProvider/0.23.0</packageSourceUrl>
     <tags>nuget.credentialprovider.vss nuget credentialprovider vss vso</tags>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <licenseUrl>https://www.microsoft.com/net/dotnet_library_license.htm</licenseUrl>

--- a/Nuget.CredentialProvider.VSS/tools/chocolateyinstall.ps1
+++ b/Nuget.CredentialProvider.VSS/tools/chocolateyinstall.ps1
@@ -2,12 +2,12 @@
 
 $packageName   = 'Nuget.CredentialProvider.VSS'
 $toolsDir      = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url           = 'https://www.nuget.org/api/v2/package/Microsoft.VisualStudio.Services.NuGet.CredentialProvider/0.14.0'
+$url           = 'https://www.nuget.org/api/v2/package/Microsoft.VisualStudio.Services.NuGet.CredentialProvider/0.23.0'
 $installDir    = Join-Path $env:LOCALAPPDATA "Nuget\CredentialProviders"
 
 ## Download and unpack the zip file:
 $downloadedZip = Join-Path $toolsDir 'Nuget.CredentialProvider.VSS.zip'
-Get-ChocolateyWebFile -PackageName "$packageName" -FileFullPath "$downloadedZip" -Url "$url" -Checksum "AA79AE37517A15F0807A19A6D68077188DEB2DB5CD0D886EDFC767AB5EACBB29" -ChecksumType "sha256"
+Get-ChocolateyWebFile -PackageName "$packageName" -FileFullPath "$downloadedZip" -Url "$url" -Checksum "1D59368C45A2163F75D53BEC565915DFFE0A3C2EF35DE6466570CFE502503274" -ChecksumType "sha256"
 Get-ChocolateyUnzip "$downloadedZip" "$toolsDir"
 
 if (!(Test-Path -Path "$installDir"))


### PR DESCRIPTION
The Microsoft.VisualStudio.Services.NuGet.CredentialProvider package has upgraded to version 0.23.  Moving to that, and bumping our choco package accordingly.